### PR TITLE
feat: 오류 응답 객체 및 예외 객체 설정

### DIFF
--- a/src/main/java/org/example/campuspark/global/dto/ErrorResponse.java
+++ b/src/main/java/org/example/campuspark/global/dto/ErrorResponse.java
@@ -1,0 +1,10 @@
+package org.example.campuspark.global.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ErrorResponse (
+    String errorCode,
+    String message
+){
+}

--- a/src/main/java/org/example/campuspark/global/exception/ControllerAdvice.java
+++ b/src/main/java/org/example/campuspark/global/exception/ControllerAdvice.java
@@ -1,0 +1,60 @@
+package org.example.campuspark.global.exception;
+
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.example.campuspark.global.dto.ErrorResponse;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ControllerAdvice {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.warn("Handled CustomException: code={}, status={}, msg={}",
+            e.getErrorCode(), e.getHttpStatus(), e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.builder()
+            .errorCode(e.getErrorCode())
+            .message(e.getMessage()).build();
+
+        return ResponseEntity.status(e.getHttpStatus())
+            .body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+        MethodArgumentNotValidException e) {
+        log.warn("Validation exception: status={}, msg={}",
+            e.getStatusCode(), e.getMessage());
+
+        // valid 조건을 여러 개 위배했을 수도 있음.
+        // message 여러 개를 한 개의 String으로 변환
+        String allErrorMessages = e.getBindingResult().getAllErrors().stream()
+            .map(DefaultMessageSourceResolvable::getDefaultMessage)
+            .collect(Collectors.joining(", "));
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+            .errorCode("V999")
+            .message(allErrorMessages).build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unexpected Error: ", e);
+        ErrorResponse errorResponse = ErrorResponse.builder()
+            .errorCode("E999")
+            .message("서버 내부 오류입니다.").build();
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(errorResponse);
+    }
+
+}

--- a/src/main/java/org/example/campuspark/global/exception/CustomException.java
+++ b/src/main/java/org/example/campuspark/global/exception/CustomException.java
@@ -1,0 +1,22 @@
+package org.example.campuspark.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String errorMessage;
+
+    private CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.httpStatus = errorCode.getHttpStatus();
+        this.errorCode = errorCode.getCode();
+        this.errorMessage = errorCode.getMessage();
+    }
+
+    public static CustomException from(ErrorCode errorCode) {
+        return new CustomException(errorCode);
+    }
+}

--- a/src/main/java/org/example/campuspark/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/campuspark/global/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package org.example.campuspark.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E999", "서버 내부 에러가 발생했습니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "E001", "요청한 리소스를 찾을 수 없습니다."),
+    RESOURCE_ALREADY_EXISTS(HttpStatus.CONFLICT, "E002", "이미 존재하는 리소스입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E003", "인증이 필요한 요청입니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "E004", "해당 리소스에 접근할 권한이 없습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "E005", "잘못된 요청입니다. 입력 값을 확인해주세요."),
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "E006", "유효성 검사에 실패했습니다. 올바른 값을 입력해 주세요");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
## ✨ 요약
- 공통으로 사용할 오류 응답 객체와 예외 객체, 핸들러를 추가했어요.

<br><br>

## 🔗 작업 내용
- 여러 도메인에서 공통적으로 사용할 ErrorCode 생성
- 에러 응답 객체 ErrorResponse 생성
- 여러 도메인에서 공통적으로 사용할 CustomException 생성
- 여러 Exception을 받을 ControllerAdvice 생성 및 예외 핸들러 구현

<br><br>

## 🔗 참고 사항
- 저희 개발 기간이 많이 짧아서..... 도메인 별로 ErrorCode나 Exception도 안 나누고 그냥 공통으로 사용할 수 있도록 먼저 세팅해 놓긴 했습니다.. 개발하면서 시간 좀 남으면 조금씩 리팩토링 해 보는 거 어떠신가요

<br><br>

## 🔗 관련 이슈

- #1

<br><br>
