### PR TITLE
Chore: DockerFile에서의 JDK 버전 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk
+FROM openjdk:21-jdk
 
 # 나중에 버전 하드코딩을 방지하려면 *.jar로 변경하는 게 나을 듯
 # -plain.jar 생성 방지하는 코드도 추가 필요함.


### PR DESCRIPTION
## ✨ 요약
- DockerFile에 명시된 JDK 버전을 17 -> 21로 변경했습니다.

<br><br>

## 🔗 작업 내용
- 

<br><br>

## 🔗 참고 사항
- 

<br><br>

## 🔗 관련 이슈

- Close #이슈번호

<br><br>
